### PR TITLE
Second Deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+# Usually API key are hidden but since this is a personal project
+
+# I am uploading the .env file to github on a commit for github
+
+# to handle deploys from pull requests or merges
+
+# If you wish to use your own API key replace the value of REACT_APP_API_KEY
+
+# with your own API key from Rapid API
+
+REACT_APP_API_KEY = 510b6f02edmsh0d7d24c2f413e2ep1c1c63jsn39228f0f76c0

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-.env
+

--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -30,7 +30,6 @@ export const Results = () => {
         <div className="flex flex-wrap justify-between space-y-6 sm:px-56 pt-2">
           {results?.map(({ link, title, description }, index) => (
             <div key={index} className="md:w-2/5 w-full">
-              {console.log(results)}
               <a href={link} target="_blank" rel="noopener noreferrer">
                 <p className="text-sm">
                   {link.length > 30 ? link.substring(0, 30) : link}

--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useResultContext } from "../Context/ResultContextProvider";
 import { Links } from "./Links";
 import { FcSearch } from "react-icons/fc";
@@ -7,7 +7,6 @@ import { FcSearch } from "react-icons/fc";
 export const Search = () => {
   const [text, setText] = useState("");
   const { setSearchTerm, searchTerm, getResults } = useResultContext();
-  const location = useLocation();
   const navigate = useNavigate();
 
   const handleTextChange = (e) => {


### PR DESCRIPTION
Usually, API keys are hidden but since this is a personal project I am uploading the .env file to GitHub on a commit for GitHub to handle deploys from pull requests or merges

If you wish to use your API key replace the value of REACT_APP_API_KEY with your API key from Rapid API